### PR TITLE
Adds the ability to easily reset the encoder

### DIFF
--- a/irctokens/stateful.py
+++ b/irctokens/stateful.py
@@ -24,6 +24,9 @@ class StatefulDecoder(object):
 
 class StatefulEncoder(object):
     def __init__(self):
+        self.clear()
+        
+    def clear(self):
         self._buffer = b""
         self._buffered_lines: typing.List[Line] = []
 
@@ -33,6 +36,7 @@ class StatefulEncoder(object):
     def push(self, line: Line):
         self._buffer += f"{line.format()}\r\n".encode("utf8")
         self._buffered_lines.append(line)
+        
     def pop(self, byte_count: int):
         sent = self._buffer[:byte_count].count("\n")
         self._buffer = self._buffer[byte_count:]


### PR DESCRIPTION
The initialize function is also refactored to use the clear function to reduce code duplication as they would be doing the same thing.