### PR TITLE
Fixes bug where line source is None and passed to Hostmask

### DIFF
--- a/irctokens/protocol.py
+++ b/irctokens/protocol.py
@@ -15,10 +15,15 @@ def _escape_tag(value: str):
 class Hostmask(object):
     def __init__(self, source: str):
         self._raw = source
-        username,      _, hostname = source.partition("@")
-        self.nickname, _, username = username.partition("!")
-        self.username = username or None
-        self.hostname = hostname or None
+        if source is None:
+            self.nickname = None
+            self.username = None
+            self.hostname = None
+        else:
+            username,      _, hostname = source.partition("@")
+            self.nickname, _, username = username.partition("!")
+            self.username = username or None
+            self.hostname = hostname or None
 
     def __str__(self) -> str:
         return self._raw

--- a/test/hostmask.py
+++ b/test/hostmask.py
@@ -33,3 +33,9 @@ class HostmaskTest(unittest.TestCase):
         self.assertEqual(line.hostmask.nickname, "nick")
         self.assertEqual(line.hostmask.username, "user")
         self.assertEqual(line.hostmask.hostname, "host")
+
+    def test_none(self):
+        hostmask = irctokens.Hostmask(None)
+        self.assertIsNone(hostmask.nickname)
+        self.assertIsNone(hostmask.username)
+        self.assertIsNone(hostmask.hostname)


### PR DESCRIPTION
Specifically addresses this exception:
```
ERROR:
Traceback (most recent call last):
  ...
  File "./env/lib64/python3.6/site-packages/irctokens/protocol.py", line 58, in hostmask
    self._hostmask = self._hostmask or Hostmask(self.source)
  File "./env/lib64/python3.6/site-packages/irctokens/protocol.py", line 18, in __init__
    username,      _, hostname = source.partition("@")
AttributeError: 'NoneType' object has no attribute 'partition'
```