### PR TITLE
Typing cleanup

### DIFF
--- a/irctokens/__init__.py
+++ b/irctokens/__init__.py
@@ -1,4 +1,13 @@
-from .line     import Line, build, tokenise
 from .hostmask import Hostmask, hostmask
+from .line import Line, build, tokenise
 from .stateful import StatefulDecoder, StatefulEncoder
 
+__all__ = [
+    "Line",
+    "build",
+    "tokenise",
+    "Hostmask",
+    "hostmask",
+    "StatefulDecoder",
+    "StatefulEncoder",
+]

--- a/irctokens/const.py
+++ b/irctokens/const.py
@@ -1,2 +1,2 @@
-TAG_UNESCAPED = ["\\",   " ",   ";",   "\r",  "\n"]
-TAG_ESCAPED   = ["\\\\", "\\s", "\\:", "\\r", "\\n"]
+TAG_UNESCAPED = ("\\", " ", ";", "\r", "\n")
+TAG_ESCAPED = ("\\\\", "\\s", "\\:", "\\r", "\\n")

--- a/irctokens/formatting.py
+++ b/irctokens/formatting.py
@@ -1,29 +1,37 @@
-from typing import Dict, List, Optional
+from __future__ import annotations
+
 from .const import TAG_ESCAPED, TAG_UNESCAPED
+
 
 def _escape_tag(value: str):
     for i, char in enumerate(TAG_UNESCAPED):
         value = value.replace(char, TAG_ESCAPED[i])
+
     return value
 
+
 def format(
-        tags:    Optional[Dict[str, str]],
-        source:  Optional[str],
-        command: str,
-        params:  List[str]):
-    outs: List[str] = []
+    tags: dict[str, str] | None,
+    source: str | None,
+    command: str,
+    params: list[str],
+):
+    outs: list[str] = []
     if tags:
         tags_str = []
         for key in sorted(tags.keys()):
             if tags[key]:
                 value = tags[key]
                 tags_str.append(f"{key}={_escape_tag(value)}")
+
             else:
                 tags_str.append(key)
+
         outs.append(f"@{';'.join(tags_str)}")
 
     if source is not None:
         outs.append(f":{source}")
+
     outs.append(command)
 
     params = params.copy()
@@ -32,13 +40,15 @@ def format(
         for param in params:
             if " " in param:
                 raise ValueError("non last params cannot have spaces")
+
             elif param.startswith(":"):
                 raise ValueError("non last params cannot start with colon")
+
         outs.extend(params)
 
-        if (not last or
-                " " in last or
-                last.startswith(":")):
+        if not last or " " in last or last.startswith(":"):
             last = f":{last}"
+
         outs.append(last)
+
     return " ".join(outs)

--- a/irctokens/hostmask.py
+++ b/irctokens/hostmask.py
@@ -1,30 +1,35 @@
-from typing import Optional
+from __future__ import annotations
 
-class Hostmask(object):
-    def __init__(self, source: str,
-            nickname: str,
-            username: Optional[str],
-            hostname: Optional[str]):
-        self._source = source
-        self.nickname = nickname
-        self.username = username
-        self.hostname = hostname
+from dataclasses import dataclass
+
+
+@dataclass
+class Hostmask:
+    source: str
+    nickname: str
+    username: str | None
+    hostname: str | None
 
     def __str__(self) -> str:
-        return self._source
+        return self.source
+
     def __repr__(self) -> str:
-        return f"Hostmask({self._source})"
+        return f"Hostmask({self.source})"
+
     def __eq__(self, other) -> bool:
-        if isinstance(other, Hostmask):
-            return str(self) == str(other)
-        else:
+        if not isinstance(other, Hostmask):
             return False
+
+        return self.source == other.source
+
 
 def hostmask(source: str) -> Hostmask:
     username, _, hostname = source.partition("@")
     nickname, _, username = username.partition("!")
+
     return Hostmask(
-        source,
-        nickname,
-        username or None,
-        hostname or None)
+        source=source,
+        nickname=nickname,
+        username=username or None,
+        hostname=hostname or None,
+    )

--- a/irctokens/stateful.py
+++ b/irctokens/stateful.py
@@ -1,8 +1,10 @@
-from typing import List, Optional
-from .line  import Line, tokenise
+from __future__ import annotations
 
-class StatefulDecoder(object):
-    def __init__(self, encoding: str="utf8", fallback: str="latin-1"):
+from .line import Line, tokenise
+
+
+class StatefulDecoder:
+    def __init__(self, encoding: str = "utf8", fallback: str = "latin-1"):
         self._encoding = encoding
         self._fallback = fallback
         self.clear()
@@ -13,27 +15,29 @@ class StatefulDecoder(object):
     def pending(self) -> bytes:
         return self._buffer
 
-    def push(self, data: bytes) -> Optional[List[Line]]:
+    def push(self, data: bytes) -> list[Line] | None:
         if not data:
             return None
 
         self._buffer += data
-        lines_b = [l.strip(b"\r") for l in self._buffer.split(b"\n")]
+        lines_b = [ln.strip(b"\r") for ln in self._buffer.split(b"\n")]
         self._buffer = lines_b.pop(-1)
 
-        lines: List[Line] = []
+        lines: list[Line] = []
         for line in lines_b:
             lines.append(tokenise(line, self._encoding, self._fallback))
+
         return lines
 
-class StatefulEncoder(object):
-    def __init__(self, encoding: str="utf8"):
+
+class StatefulEncoder:
+    def __init__(self, encoding: str = "utf8"):
         self._encoding = encoding
         self.clear()
 
     def clear(self):
         self._buffer = b""
-        self._buffered_lines: List[Line] = []
+        self._buffered_lines: list[Line] = []
 
     def pending(self) -> bytes:
         return self._buffer
@@ -45,4 +49,5 @@ class StatefulEncoder(object):
     def pop(self, byte_count: int):
         sent = self._buffer[:byte_count].count(b"\n")
         self._buffer = self._buffer[byte_count:]
+
         return [self._buffered_lines.pop(0) for _ in range(sent)]


### PR DESCRIPTION
Removes some deprecated things (subclassing `object`), updates annotations to 3.10 spec (and uses future imports to maintain compat with 3.7 -- I dont think there are any 3.6 issues here, but the future import is from 3.7)

Generally formatted all files with black